### PR TITLE
Fix reversion imports, dependencies, fabfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ staticfiles/
 
 # Testing coverage
 .coverage
+
+# generated Supervisor conf
+biosys.conf

--- a/biosys/apps/animals/admin.py
+++ b/biosys/apps/animals/admin.py
@@ -1,12 +1,12 @@
 from django.contrib import admin
 from django.utils.text import Truncator
-import reversion
+from reversion.admin import VersionAdmin
 from models import *
 from main.admin import AbstractLookupAdmin
 
 
 @admin.register(Trap)
-class TrapAdmin(reversion.VersionAdmin):
+class TrapAdmin(VersionAdmin):
     list_display = [
         'trapline_ID', 'trap_type', 'site_visit', 'open_date', 'close_date',
         'comments_display']
@@ -20,7 +20,7 @@ class TrapAdmin(reversion.VersionAdmin):
 
 
 @admin.register(AnimalObservation)
-class AnimalObservationAdmin(reversion.VersionAdmin):
+class AnimalObservationAdmin(VersionAdmin):
     list_display = [
         'site_visit', 'collector', 'date', 'trap_no', 'trap_type', 'species',
         'microchip_id',  'comments_display']
@@ -35,7 +35,7 @@ class AnimalObservationAdmin(reversion.VersionAdmin):
 
 
 @admin.register(OpportunisticObservation)
-class OpportunisticObservationAdmin(reversion.VersionAdmin):
+class OpportunisticObservationAdmin(VersionAdmin):
     list_display = ['site_visit', 'date', 'observer', 'species', 'comments_display']
     list_filter = ['site_visit', 'species']
     date_hierarchy = 'date'

--- a/biosys/apps/main/admin.py
+++ b/biosys/apps/main/admin.py
@@ -13,7 +13,7 @@ from django.template.response import TemplateResponse
 from django.utils.encoding import force_text
 from django.utils.http import urlencode
 from django.views.generic import RedirectView
-import reversion
+from reversion.admin import VersionAdmin
 
 from upload.models import SiteVisitDataFileError
 from upload.validation import SiteDataFileValidator, SiteVisitDataBuilder
@@ -47,7 +47,7 @@ def user_can_approve(user):
     return user.is_superuser or user.groups.filter(name=CUSTODIANS).exists()
 
 
-class MainAppAdmin(reversion.VersionAdmin):
+class MainAppAdmin(VersionAdmin):
     change_form_template = 'main/main_change_form.html'
     change_list_template = 'main/main_change_list.html'
 
@@ -329,7 +329,7 @@ class VisitAdmin(MainAppAdmin):
 
 
 @admin.register(SiteCharacteristic)
-class SiteCharacteristicAdmin(reversion.VersionAdmin):
+class SiteCharacteristicAdmin(VersionAdmin):
     list_display = [
         'site_visit', 'underlaying_geology', 'closest_water_distance',
         'closest_water_type', 'landform_pattern', 'landform_element',
@@ -504,13 +504,13 @@ class SiteVisitDataFileAdmin(MainAppAdmin):
 
 
 @admin.register(SiteVisitDataSheetTemplate)
-class SiteVisitDataSheetTemplateAdmin(reversion.VersionAdmin):
+class SiteVisitDataSheetTemplateAdmin(VersionAdmin):
     list_display = ['filename', 'version']
     form = forms.SiteVisitDataSheetTemplateForm
 
 
 @admin.register(SpeciesObservation)
-class SpeciesObservationAdmin(reversion.VersionAdmin):
+class SpeciesObservationAdmin(VersionAdmin):
     list_display = ['input_name', 'name_id', 'valid', 'site_visit']
     pass
 
@@ -519,7 +519,7 @@ class SpeciesObservationAdmin(reversion.VersionAdmin):
 # Lookups
 #########################
 
-class AbstractLookupAdmin(reversion.VersionAdmin):
+class AbstractLookupAdmin(VersionAdmin):
     list_display = ['value', 'code', 'deprecated']
 
 

--- a/biosys/apps/main/models.py
+++ b/biosys/apps/main/models.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 import datetime
 from django.db import transaction
 from os import path
-import reversion
+from reversion import revisions as reversion
 
 from django.db.models import Max
 from django.contrib.gis.db import models
@@ -254,7 +254,7 @@ class SiteVisit(models.Model):
     def is_approved(self):
         return self.data_status == self.DATA_STATUS_APPROVED
 
-    @ property
+    @property
     def is_quarantined(self):
         return self.data_status == self.DATA_STATUS_QUAR
 

--- a/biosys/apps/upload/admin.py
+++ b/biosys/apps/upload/admin.py
@@ -1,11 +1,11 @@
 from django.contrib import admin
-import reversion
+from reversion.admin import VersionAdmin
 
 from models import *
 
 
 @admin.register(SiteVisitDataFileError)
-class SiteVisitDataFileErrorAdmin(reversion.VersionAdmin):
+class SiteVisitDataFileErrorAdmin(VersionAdmin):
     list_display = ['file', 'message']
     readonly_fields = ['file']
     change_form_template = 'upload/sitevisitdatafile_change_form.html'

--- a/biosys/apps/vegetation/admin.py
+++ b/biosys/apps/vegetation/admin.py
@@ -1,67 +1,67 @@
 from django.contrib import admin
-import reversion
+from reversion.admin import VersionAdmin
 from models import *
 from main.admin import AbstractLookupAdmin
 
 
 @admin.register(VegetationVisit)
-class VegetationVisitAdmin(reversion.VersionAdmin):
+class VegetationVisitAdmin(VersionAdmin):
     list_display = ('site_visit', 'collector', 'date')
 
 
 @admin.register(BasalBitterlichObservation)
-class BasalBitterlichObservationAdmin(reversion.VersionAdmin):
+class BasalBitterlichObservationAdmin(VersionAdmin):
     pass
 
 
 @admin.register(GroundCoverSummary)
-class GroundCoverSummaryAdmin(reversion.VersionAdmin):
+class GroundCoverSummaryAdmin(VersionAdmin):
     pass
 
 
 @admin.register(TransectObservation)
-class TransectObservationAdmin(reversion.VersionAdmin):
+class TransectObservationAdmin(VersionAdmin):
     pass
 
 
 @admin.register(TransectDistinctChanges)
-class TransectDistinctChangesAdmin(reversion.VersionAdmin):
+class TransectDistinctChangesAdmin(VersionAdmin):
     pass
 
 
 @admin.register(ErosionPeg)
-class ErosionPegAdmin(reversion.VersionAdmin):
+class ErosionPegAdmin(VersionAdmin):
     list_display = ('__str__', 'vegetation_visit', 'transect_x', 'transect_y')
     list_filter = ('vegetation_visit', )
 
 
 @admin.register(PegObservation)
-class PegObservationAdmin(reversion.VersionAdmin):
+class PegObservationAdmin(VersionAdmin):
     pass
 
 
 @admin.register(StratumSummary)
-class StratumSummaryAdmin(reversion.VersionAdmin):
+class StratumSummaryAdmin(VersionAdmin):
     pass
 
 
 @admin.register(StratumSpecies)
-class StratumSpeciesAdmin(reversion.VersionAdmin):
+class StratumSpeciesAdmin(VersionAdmin):
     list_display = ('vegetation_visit', 'significance', 'stratum', 'species')
 
 
 @admin.register(DisturbanceIndicator)
-class DisturbanceIndicatorAdmin(reversion.VersionAdmin):
+class DisturbanceIndicatorAdmin(VersionAdmin):
     pass
 
 
 @admin.register(BiodiversityIndicator)
-class BiodiversityIndicatorAdmin(reversion.VersionAdmin):
+class BiodiversityIndicatorAdmin(VersionAdmin):
     pass
 
 
 @admin.register(PlantObservation)
-class PlantObservationAdmin(reversion.VersionAdmin):
+class PlantObservationAdmin(VersionAdmin):
     pass
 
 #########################

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,5 +1,5 @@
 import os
-from fabric.api import cd, run
+from fabric.api import cd, run, sudo
 from fabric.contrib.files import exists, upload_template
 
 DEPLOY_REPO_URL = os.environ['DEPLOY_REPO_URL']
@@ -42,7 +42,7 @@ def _update_venv():
     with cd(DEPLOY_VENV_PATH):
         if not exists('{}/bin/pip'.format(DEPLOY_VENV_NAME)):
             run('virtualenv {}'.format(DEPLOY_VENV_NAME))
-        run('{}/bin/pip install -r requirements/base.txt'.format(DEPLOY_VENV_NAME))
+        run('{}/bin/pip install -r {}/requirements.txt'.format(DEPLOY_VENV_NAME, DEPLOY_TARGET))
 
 
 def _setup_env():
@@ -56,7 +56,9 @@ def _setup_env():
             'DEPLOY_SESSION_COOKIE_SECURE': DEPLOY_SESSION_COOKIE_SECURE,
             'KMI_PASSWORD': KMI_PASSWORD,
         }
-        upload_template('biosys/templates/env.jinja', '.env', context, use_jinja=True, backup=False)
+        if not exists('.env'):
+            upload_template('biosys/templates/env.jinja', '.env', context,
+                            use_jinja=True, backup=False)
 
 
 def _setup_supervisor_conf():
@@ -69,13 +71,14 @@ def _setup_supervisor_conf():
             'DEPLOY_VENV_NAME': DEPLOY_VENV_NAME,
         }
         upload_template(
-            'biosys/templates/supervisor.jinja', '{}.conf'.format(DEPLOY_SUPERVISOR_NAME),
+            'biosys/templates/supervisor.jinja', '{}/{}.conf'.format(
+            DEPLOY_TARGET, DEPLOY_SUPERVISOR_NAME),
             context, use_jinja=True, backup=False)
 
 
 def _chown():
     # Assumes that the DEPLOY_USER user exists on the target server.
-    run('chown -R {0}:{0} {1}'.format(DEPLOY_USER, DEPLOY_TARGET))
+    sudo('chown -R {0}:{0} {1}'.format(DEPLOY_USER, DEPLOY_TARGET))
 
 
 def _collectstatic():

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,5 +1,6 @@
 import os
 from fabric.api import cd, run, sudo
+from fabric.colors import green, yellow, red
 from fabric.contrib.files import exists, upload_template
 
 DEPLOY_REPO_URL = os.environ['DEPLOY_REPO_URL']
@@ -56,7 +57,9 @@ def _setup_env():
             'DEPLOY_SESSION_COOKIE_SECURE': DEPLOY_SESSION_COOKIE_SECURE,
             'KMI_PASSWORD': KMI_PASSWORD,
         }
-        if not exists('.env'):
+        if exists('.env'):
+            print(yellow("The existing .env file will be used."))
+        else:
             upload_template('biosys/templates/env.jinja', '.env', context,
                             use_jinja=True, backup=False)
 
@@ -70,10 +73,14 @@ def _setup_supervisor_conf():
             'DEPLOY_VENV_PATH': DEPLOY_VENV_PATH,
             'DEPLOY_VENV_NAME': DEPLOY_VENV_NAME,
         }
-        upload_template(
-            'biosys/templates/supervisor.jinja', '{}/{}.conf'.format(
-            DEPLOY_TARGET, DEPLOY_SUPERVISOR_NAME),
-            context, use_jinja=True, backup=False)
+        if exists('{}/{}.conf'.format(DEPLOY_TARGET, DEPLOY_SUPERVISOR_NAME)):
+            print(yellow("The existing supervisor config file {}/{}.conf will be used.".format(
+                DEPLOY_TARGET, DEPLOY_SUPERVISOR_NAME)))
+        else:
+            upload_template(
+                'biosys/templates/supervisor.jinja', '{}/{}.conf'.format(
+                DEPLOY_TARGET, DEPLOY_SUPERVISOR_NAME),
+                context, use_jinja=True, backup=False)
 
 
 def _chown():

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ django-grappelli>=2.6.5
 django-envelope>=1.0
 django-braces>=1.8.0
 django-debug-toolbar>=1.3.0
+django-wsgiserver
 # Testing requirements
 coverage==3.7.1
 flake8==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,8 @@ django-grappelli>=2.6.5
 django-envelope>=1.0
 django-braces>=1.8.0
 django-debug-toolbar>=1.3.0
-django-wsgiserver
+django-wsgiserver>=0.6.10
+dj-static==0.0.6
 # Testing requirements
 coverage==3.7.1
 flake8==2.4.0


### PR DESCRIPTION
Overall purpose: Getting biosys setup from scratch to work in a new environment.
Documentation written at https://confluence.dpaw.wa.gov.au/display/KM/BioSys+Development
Includes and supersedes #4 

# reversion
* Follow upgrade instructions in [django-reversion changelog](https://github.com/etianen/django-reversion/blob/master/CHANGELOG.md)
* modified imports of VersionAdmin in admin classes 
* modified imports of reversion in main/models.py

# fabfile
* Honour existing .env and supervisor config files and print coloured messages if found
* fix paths by prepending DEPLOY_TARGET
* use sudo for the chown task
* TODO create db step is broken

# requirements.txt
Added two missing requirements:
* django-wsgiserver (with >= to get upgrades)
* dj-static (with == to keep the currently working version)