### PR TITLE
6544 6624

### DIFF
--- a/biosys/apps/main/api/serializers.py
+++ b/biosys/apps/main/api/serializers.py
@@ -74,7 +74,7 @@ class DatasetSerializer(serializers.ModelSerializer):
             if different_type or different_data_package:
                 message = "This dataset already contains records. " \
                           "You cannot change this field. " \
-                          "In order to change this you first need to delete all its records."
+                          "In order to change this dataset you first need to delete all its records."
                 response = {}
                 if different_type:
                     response['type'] = message

--- a/biosys/apps/main/api/serializers.py
+++ b/biosys/apps/main/api/serializers.py
@@ -74,7 +74,7 @@ class DatasetSerializer(serializers.ModelSerializer):
             if different_type or different_data_package:
                 message = "This dataset already contains records. " \
                           "You cannot change this field. " \
-                          "Please delete the dataset, recreate it and re-import the records."
+                          "In order to change this you first need to delete all its records."
                 response = {}
                 if different_type:
                     response['type'] = message

--- a/biosys/apps/main/api/validators.py
+++ b/biosys/apps/main/api/validators.py
@@ -116,8 +116,11 @@ class ObservationValidator(GenericRecordValidator):
         if self.site_col and self.site_col in result.warnings:
             result.add_column_error(self.site_col, result.warnings[self.site_col])
             del result.warnings[self.site_col]
-        result = result.merge(self.validate_date(data))
-        result = result.merge(self.validate_geometry(data))
+
+        # validate the date and the geometry values. To be done only if there's no schema error
+        if not result.has_errors:
+            result = result.merge(self.validate_date(data))
+            result = result.merge(self.validate_geometry(data))
         return result
 
     def validate_date(self, data):
@@ -164,7 +167,10 @@ class SpeciesObservationValidator(ObservationValidator):
         if self.species_name_id_col and self.species_name_id_col in result.warnings:
             result.add_column_error(self.species_name_id_col, result.warnings[self.species_name_id_col])
             del result.warnings[self.species_name_id_col]
-        result = result.merge(self.validate_species(data))
+
+        # validate the species. To be done only if there's no schema error
+        if not result.has_errors:
+            result = result.merge(self.validate_species(data))
         return result
 
     def validate_species(self, data):

--- a/biosys/apps/main/tests/api/test_observation.py
+++ b/biosys/apps/main/tests/api/test_observation.py
@@ -1,7 +1,6 @@
 import datetime
 import re
 from os import path
-from unittest import skip
 
 from django.contrib.auth.models import User
 from django.contrib.gis.geos import Point
@@ -1425,7 +1424,6 @@ class TestGeometryFromSite(helpers.BaseUserTestCase):
             self.assertEqual(r.site, site_1)
             self.assertEqual(r.geometry, site_1_geometry)
 
-    @skip('Wait for the implementation')
     def test_site_geometry_updated(self):
         """
         Use case:
@@ -1475,9 +1473,12 @@ class TestGeometryFromSite(helpers.BaseUserTestCase):
             previous_geometry = site_1_geometry
             new_geometry = Point(previous_geometry.x + 2, previous_geometry.y + 2)
             self.assertNotEqual(previous_geometry, new_geometry)
-            site_1.geometry = new_geometry
-            site_1.save()
-
+            url = reverse('api:site-detail', kwargs={'pk': site_1.pk})
+            payload = {
+                "geometry": new_geometry.wkt
+            }
+            resp = client.patch(url, data=payload, format='json')
+            self.assertEqual(resp.status_code, 200)
             # check that the record has been updated
             record_1.refresh_from_db()
             self.assertEqual(record_1.geometry, new_geometry)


### PR DESCRIPTION
#6544: fix double error messages when editing record with lat/long schema error
#6624: Improved (?) error message when updating dataset with records

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/parksandwildlife/biosys/32)
<!-- Reviewable:end -->
