### PR TITLE
Fix Swagger problems with the new added 'sso-api' url patterns

### DIFF
--- a/biosys/urls.py
+++ b/biosys/urls.py
@@ -47,7 +47,8 @@ urlpatterns = \
         url(r'^about/', TemplateView.as_view(template_name='main/about.html'), name='about'),
 
         # api
-        url(r'^sso-api|^api/', include(api_urls, namespace='api')),
+        url(r'^api/', include(api_urls, namespace='api')),
+        url(r'^sso-api/', include(api_urls, namespace='sso-api')),
 
         # legacy
         url(r'^grappelli/', include('grappelli.urls')),  # Grappelli URLS


### PR DESCRIPTION
Excluded 'sso-api' patterns fromAPI schema.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/parksandwildlife/biosys/38)
<!-- Reviewable:end -->
