### PR TITLE
Strip strings before calling the cast

### DIFF
--- a/biosys/apps/main/tests/test_data_package.py
+++ b/biosys/apps/main/tests/test_data_package.py
@@ -1153,3 +1153,66 @@ class TestSpeciesObservationSchemaCast(TestCase):
         }
         schema = SpeciesObservationSchema(descriptor)
         self.assertEqual(species_name, schema.cast_species_name(record))
+
+    def test_space_stripping(self):
+        """
+        The cast should strip leading and trailing spaces
+        """
+        descriptor = clone(SPECIES_OBSERVATION_SCHEMA)
+        species_name = 'Chubby Bat'
+        record = {
+            'Observation Date': "18/08/2016",
+            'Latitude': -32,
+            'Longitude': 115,
+            'Species Name': '  Chubby Bat  '
+        }
+        schema = SpeciesObservationSchema(descriptor)
+        self.assertEqual(species_name, schema.cast_species_name(record))
+
+    def test_blank(self):
+        """
+        Blank string should raise an exception
+        :return:
+        """
+        descriptor = clone(SPECIES_OBSERVATION_SCHEMA)
+        record = {
+            'Observation Date': "18/08/2016",
+            'Latitude': -32,
+            'Longitude': 115,
+            'Species Name': '   '
+        }
+        schema = SpeciesObservationSchema(descriptor)
+        with self.assertRaises(Exception):
+            schema.cast_species_name(record)
+
+    def test_none(self):
+        """
+        None should raise an exception
+        :return:
+        """
+        descriptor = clone(SPECIES_OBSERVATION_SCHEMA)
+        record = {
+            'Observation Date': "18/08/2016",
+            'Latitude': -32,
+            'Longitude': 115,
+            'Species Name': None
+        }
+        schema = SpeciesObservationSchema(descriptor)
+        with self.assertRaises(Exception):
+            schema.cast_species_name(record)
+
+    def test_number(self):
+        """
+        Number should raise an exception
+        :return:
+        """
+        descriptor = clone(SPECIES_OBSERVATION_SCHEMA)
+        record = {
+            'Observation Date': "18/08/2016",
+            'Latitude': -32,
+            'Longitude': 115,
+            'Species Name': 1234
+        }
+        schema = SpeciesObservationSchema(descriptor)
+        with self.assertRaises(Exception):
+            schema.cast_species_name(record)

--- a/biosys/apps/main/utils_data_package.py
+++ b/biosys/apps/main/utils_data_package.py
@@ -291,10 +291,12 @@ class SchemaField:
         :param value:
         :return:
         """
-        # TODO: remove that when running in Python3
-        if isinstance(value, six.string_types) and not isinstance(value, six.text_type):
-            # the StringType accepts only unicode
-            value = six.u(value)
+        if isinstance(value, six.string_types):
+            value = value.strip()
+            # TODO: remove that when running in Python3
+            if not isinstance(value, six.text_type):
+                # the StringType accepts only unicode
+                value = six.u(value).strip()
         return self.type.cast(value)
 
     def validation_error(self, value):


### PR DESCRIPTION
Avoid species name to have heading or trailing spaces.
See:
https://www.decbugs.com/view.php?id=6716

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/parksandwildlife/biosys/39)
<!-- Reviewable:end -->
